### PR TITLE
Two small fixes to new build system

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,7 @@ AM_CFLAGS = -I$(top_srcdir)/librtas_src/ -I$(top_srcdir)/librtasevent_src/
 
 library_includedir=$(includedir)
 
-LIBRTAS_LIBRARY_VERSION = 2:0:0
+LIBRTAS_LIBRARY_VERSION = $(subst .,:,$(PACKAGE_VERSION))
 
 lib_LTLIBRARIES += librtas.la
 librtas_la_LDFLAGS = -version-info $(LIBRTAS_LIBRARY_VERSION)

--- a/librtas.pc.in
+++ b/librtas.pc.in
@@ -6,5 +6,5 @@ includedir=@includedir@
 Name: librtas
 Description: The librtas package provides an interface for Run-Time Abstraction Services (RTAS) calls on PAPR platforms. The libraries allow users to examine and manipulate hardware, and parse RTAS events.
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lrtas-2.0 -lofdt-2.0 -lrtasevent-2.0
-Cflags: -I${includedir}/librtas-2.0 -I${libdir}/librtas-2.0/include
+Libs: -L${libdir} -lrtas -lrtasevent
+Cflags: -I${includedir}


### PR DESCRIPTION
The first commit just fixes the pkgconfig file to actually match reality as the library is installed on the filesystem.  It should be fairly self-explanatory.

The second commit is just a release management optimization that operates on the assumption that you intend to use your major version number to track ABI.  If so, it makes sense to just keep the package version and the library version in sync.  If that was the intent, this makes it so you only have to update the version in configure.ac, rather than in two spots.  If that wasn't your intent, obviously you can skip this commit and just pull the first.
