### PR TITLE
Update library version to 2.0.1 to match with release version

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,9 @@ AM_CFLAGS = -I$(top_srcdir)/librtas_src/ -I$(top_srcdir)/librtasevent_src/
 
 library_includedir=$(includedir)
 
-LIBRTAS_LIBRARY_VERSION = 2:0:0
+# CURRENT:REVISION:AGE(C:R:A)
+# For calculating version number of library, formula used is (C - A).(A).(R)
+LIBRTAS_LIBRARY_VERSION = 2:1:0
 
 lib_LTLIBRARIES += librtas.la
 librtas_la_LDFLAGS = -version-info $(LIBRTAS_LIBRARY_VERSION)


### PR DESCRIPTION
While building librtas-2.0.1, libraries generated are librtasevent.so.2.0.0 and librtas.so.2.0.0 . But since this is 2.0.1 release, expected version of libraries are librtasevent.so.2.0.1 and librtas.so.2.0.1 . This patch modifies Makefile.am LIBRTAS_LIBRARY_VERSION  variable value appropriately to get right version of libraries. 

More details of how library version is calculated is mentioned at http://openbooks.sourceforge.net/books/wga/dealing-with-libraries.html in section "A Note about Version Numbers"