### PR TITLE
ci: add GitHub Actions build tests

### DIFF
--- a/.github/problem-matchers/compiler-source.json
+++ b/.github/problem-matchers/compiler-source.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "gcc-problem-matcher",
+            "pattern": [
+                {
+                    "regexp": "^(.*?):(\\d+):(\\d*):?\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,47 @@
+name: CI
+
+# Controls when the workflow will run.
+on:
+  # This allows the build to be triggered manually via the github UI.
+  workflow_dispatch:
+
+  # Push to any branch
+  push:
+
+  # Any pull request
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        host: [powerpc-linux-gnu, powerpc64-linux-gnu, powerpc64le-linux-gnu, x86_64-linux-gnu]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Register problem matchers
+      run: |
+        echo "::add-matcher::.github/problem-matchers/compiler-source.json"
+
+    - name: Install cross compiler
+      if: matrix.host != 'x86_64-linux-gnu'
+      run: |
+        sudo apt update
+        sudo apt install -y gcc-${{ matrix.host }}
+
+    - name: autogen
+      run: ./autogen.sh
+
+    - name: configure
+      run: ./configure --host=${{ matrix.host }}
+
+    - name: make
+      run: make
+
+    - name: distcheck
+      run: |
+        make distcheck DISTCHECK_CONFIGURE_FLAGS=--host=${{ matrix.host }}
+        file .libs/librtas.so*


### PR DESCRIPTION
GitHub's hosted x86 Ubuntu runners have cross toolchains suitable for
building librtas for its targeted architectures. Add a matrix build
including these (32- and 64-bit big-endian, 64-bit little-endian) which
performs a basic build and distcheck.

Also perform a native x86 build since it "works": it produces nothing you
would want to run, but the build succeeds. If we are to add tests in the
future, running them as native code on the build host may be the best
option. So it's in our interest to keep the x86 build working.

Signed-off-by: Nathan Lynch <nathanl@linux.ibm.com>