### PR TITLE
librtasevent: fix 'taking address of packed member' warnings

### DIFF
--- a/librtasevent_src/get_rtas_event.c
+++ b/librtasevent_src/get_rtas_event.c
@@ -279,8 +279,8 @@ static void parse_re_exthdr(struct rtas_event *re,
     rex_hdr->config_change = (rawhdr->data4 & 0x02) >> 1;
     rex_hdr->post = rawhdr->data4 & 0x01;
 
-    parse_rtas_time(&rex_hdr->time, &rawhdr->time);
-    parse_rtas_date(&rex_hdr->date, &rawhdr->date);
+    parse_rtas_time(&rex_hdr->time, rawhdr->time);
+    parse_rtas_date(&rex_hdr->date, rawhdr->date);
 
     re->offset += RE_EXT_HDR_SZ;
     add_re_scn(re, rex_hdr, RTAS_EVENT_EXT_HDR);

--- a/librtasevent_src/rtas_event.h
+++ b/librtasevent_src/rtas_event.h
@@ -34,8 +34,8 @@
 void rtas_copy(void *, struct rtas_event *, uint32_t);
 
 /* parse routines */
-void parse_rtas_date(struct rtas_date *, struct rtas_date_raw *);
-void parse_rtas_time(struct rtas_time *, struct rtas_time_raw *);
+void parse_rtas_date(struct rtas_date *, struct rtas_date_raw);
+void parse_rtas_time(struct rtas_time *, struct rtas_time_raw);
 void parse_v6_hdr(struct rtas_v6_hdr *, struct rtas_v6_hdr_raw *);
 
 int parse_priv_hdr_scn(struct rtas_event *);

--- a/librtasevent_src/rtas_v6_misc.c
+++ b/librtasevent_src/rtas_v6_misc.c
@@ -40,19 +40,19 @@ static char *months[] = {"", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
                          "Dec"};
 
 void parse_rtas_date(struct rtas_date *rtas_date,
-		     struct rtas_date_raw *rawdate)
+		     struct rtas_date_raw rawdate)
 {
-    rtas_date->year = be16toh(rawdate->year);
-    rtas_date->month = rawdate->month;
-    rtas_date->day = rawdate->day;
+    rtas_date->year = be16toh(rawdate.year);
+    rtas_date->month = rawdate.month;
+    rtas_date->day = rawdate.day;
 }
 
-void parse_rtas_time(struct rtas_time *rtas_time, struct rtas_time_raw *rawtime)
+void parse_rtas_time(struct rtas_time *rtas_time, struct rtas_time_raw rawtime)
 {
-    rtas_time->hour = rawtime->hour;
-    rtas_time->minutes = rawtime->minutes;
-    rtas_time->seconds = rawtime->seconds;
-    rtas_time->hundredths = rawtime->hundredths;
+    rtas_time->hour = rawtime.hour;
+    rtas_time->minutes = rawtime.minutes;
+    rtas_time->seconds = rawtime.seconds;
+    rtas_time->hundredths = rawtime.hundredths;
 }
 
 void parse_v6_hdr(struct rtas_v6_hdr *v6hdr, struct rtas_v6_hdr_raw *rawv6)
@@ -116,8 +116,8 @@ parse_priv_hdr_scn(struct rtas_event *re)
 
     rawhdr = (struct rtas_priv_hdr_scn_raw *)(re->buffer + re->offset);
     parse_v6_hdr(&privhdr->v6hdr, &rawhdr->v6hdr);
-    parse_rtas_date(&privhdr->date, &rawhdr->date);
-    parse_rtas_time(&privhdr->time, &rawhdr->time);
+    parse_rtas_date(&privhdr->date, rawhdr->date);
+    parse_rtas_time(&privhdr->time, rawhdr->time);
 
     privhdr->creator_id = rawhdr->creator_id;
     privhdr->scn_count = rawhdr->scn_count;


### PR DESCRIPTION
Address the following warnings:

Warning: librtasevent_src/get_rtas_event.c:282:37: warning: taking address
of packed member of ‘struct rtas_event_exthdr_raw’ may result in an
unaligned pointer value [-Waddress-of-packed-member]
  282 |     parse_rtas_time(&rex_hdr->time, &rawhdr->time);
      |                                     ^~~~~~~~~~~~~
Warning: librtasevent_src/get_rtas_event.c:283:37: warning: taking address
of packed member of ‘struct rtas_event_exthdr_raw’ may result in an
unaligned pointer value [-Waddress-of-packed-member]
  283 |     parse_rtas_date(&rex_hdr->date, &rawhdr->date);
      |                                     ^~~~~~~~~~~~~
librtasevent_src/rtas_v6_misc.c: In function ‘parse_priv_hdr_scn’:
Warning: librtasevent_src/rtas_v6_misc.c:119:37: warning: taking address of
packed member of ‘struct rtas_priv_hdr_scn_raw’ may result in an unaligned
pointer value [-Waddress-of-packed-member]
  119 |     parse_rtas_date(&privhdr->date, &rawhdr->date);
      |                                     ^~~~~~~~~~~~~
Warning: librtasevent_src/rtas_v6_misc.c:120:37: warning: taking address of
packed member of ‘struct rtas_priv_hdr_scn_raw’ may result in an unaligned
pointer value [-Waddress-of-packed-member]
  120 |     parse_rtas_time(&privhdr->time, &rawhdr->time);
      |                                     ^~~~~~~~~~~~~

by passing the small "raw" date/time objects by value instead of taking their
addresses.

Fixes #16.

Signed-off-by: Nathan Lynch <nathanl@linux.ibm.com>