### PR TITLE
Make compiler warnings fatal in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       run: ./autogen.sh
 
     - name: configure
-      run: ./configure --host=${{ matrix.host }}
+      run: ./configure --host=${{ matrix.host }} CFLAGS='-Wall -Werror -O2 -g'
 
     - name: make
       run: make V=1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,9 @@ jobs:
       run: ./configure --host=${{ matrix.host }}
 
     - name: make
-      run: make
+      run: make V=1
 
     - name: distcheck
       run: |
-        make distcheck DISTCHECK_CONFIGURE_FLAGS=--host=${{ matrix.host }}
+        make distcheck V=1 DISTCHECK_CONFIGURE_FLAGS=--host=${{ matrix.host }}
         file .libs/librtas.so*

--- a/librtas_src/syscall_calls.c
+++ b/librtas_src/syscall_calls.c
@@ -513,7 +513,7 @@ int rtas_get_config_addr_info2(uint32_t config_addr, uint64_t phb_id,
 
 	*info = be32toh(be_info);
 
-	dbg("(0x%x, 0x%lx, %d) = %d, 0x%x\n", config_addr, phb_id, func,
+	dbg("(0x%x, 0x%"PRIx64", %d) = %d, 0x%x\n", config_addr, phb_id, func,
 	    rc ? rc : status, *info);
 	return rc ? rc : status;
 }
@@ -935,7 +935,7 @@ int rtas_platform_dump(uint64_t dump_tag, uint64_t sequence, void *buffer,
 	bytes_lo = be32toh(bytes_lo);
 	*bytes_ret = BITS64(bytes_hi, bytes_lo);
 
-	dbg("(0x%lx, 0x%lx, %p, %zd, %p, %p) = %d, 0x%lx, 0x%lx\n",
+	dbg("(0x%"PRIx64", 0x%"PRIx64", %p, %zd, %p, %p) = %d, 0x%"PRIx64", 0x%"PRIx64"\n",
 	     dump_tag, sequence, buffer, length, seq_next, bytes_ret,
 	     rc ? rc : status, *seq_next, *bytes_ret);
 	return rc ? rc : status;
@@ -967,7 +967,7 @@ int rtas_read_slot_reset(uint32_t cfg_addr, uint64_t phbid, int *state,
 	*state = be32toh(*state);
 	*eeh = be32toh(*eeh);
 
-	dbg("(0x%x, 0x%lx, %p, %p) = %d, %d, %d\n", cfg_addr, phbid, state,
+	dbg("(0x%x, 0x%"PRIx64", %p, %p) = %d, %d, %d\n", cfg_addr, phbid, state,
 	     eeh, rc ? rc : status, *state, *eeh);
 	return rc ? rc : status;
 }
@@ -1079,7 +1079,7 @@ int rtas_set_eeh_option(uint32_t cfg_addr, uint64_t phbid, int function)
 		       htobe32(BITS32_HI(phbid)), htobe32(BITS32_LO(phbid)),
 		       htobe32(function), &status);
 
-	dbg("(0x%x, 0x%lx, %d) = %d\n", cfg_addr, phbid, function,
+	dbg("(0x%x, 0x%"PRIx64", %d) = %d\n", cfg_addr, phbid, function,
 	     rc ? rc : status);
 	return rc ? rc : status;
 }

--- a/librtasevent_src/get_rtas_event.c
+++ b/librtasevent_src/get_rtas_event.c
@@ -279,8 +279,8 @@ static void parse_re_exthdr(struct rtas_event *re,
     rex_hdr->config_change = (rawhdr->data4 & 0x02) >> 1;
     rex_hdr->post = rawhdr->data4 & 0x01;
 
-    parse_rtas_time(&rex_hdr->time, &rawhdr->time);
-    parse_rtas_date(&rex_hdr->date, &rawhdr->date);
+    parse_rtas_time(&rex_hdr->time, rawhdr->time);
+    parse_rtas_date(&rex_hdr->date, rawhdr->date);
 
     re->offset += RE_EXT_HDR_SZ;
     add_re_scn(re, rex_hdr, RTAS_EVENT_EXT_HDR);

--- a/librtasevent_src/rtas_event.h
+++ b/librtasevent_src/rtas_event.h
@@ -34,8 +34,8 @@
 void rtas_copy(void *, struct rtas_event *, uint32_t);
 
 /* parse routines */
-void parse_rtas_date(struct rtas_date *, struct rtas_date_raw *);
-void parse_rtas_time(struct rtas_time *, struct rtas_time_raw *);
+void parse_rtas_date(struct rtas_date *, struct rtas_date_raw);
+void parse_rtas_time(struct rtas_time *, struct rtas_time_raw);
 void parse_v6_hdr(struct rtas_v6_hdr *, struct rtas_v6_hdr_raw *);
 
 int parse_priv_hdr_scn(struct rtas_event *);

--- a/librtasevent_src/rtas_v6_misc.c
+++ b/librtasevent_src/rtas_v6_misc.c
@@ -40,19 +40,19 @@ static char *months[] = {"", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
                          "Dec"};
 
 void parse_rtas_date(struct rtas_date *rtas_date,
-		     struct rtas_date_raw *rawdate)
+		     struct rtas_date_raw rawdate)
 {
-    rtas_date->year = be16toh(rawdate->year);
-    rtas_date->month = rawdate->month;
-    rtas_date->day = rawdate->day;
+    rtas_date->year = be16toh(rawdate.year);
+    rtas_date->month = rawdate.month;
+    rtas_date->day = rawdate.day;
 }
 
-void parse_rtas_time(struct rtas_time *rtas_time, struct rtas_time_raw *rawtime)
+void parse_rtas_time(struct rtas_time *rtas_time, struct rtas_time_raw rawtime)
 {
-    rtas_time->hour = rawtime->hour;
-    rtas_time->minutes = rawtime->minutes;
-    rtas_time->seconds = rawtime->seconds;
-    rtas_time->hundredths = rawtime->hundredths;
+    rtas_time->hour = rawtime.hour;
+    rtas_time->minutes = rawtime.minutes;
+    rtas_time->seconds = rawtime.seconds;
+    rtas_time->hundredths = rawtime.hundredths;
 }
 
 void parse_v6_hdr(struct rtas_v6_hdr *v6hdr, struct rtas_v6_hdr_raw *rawv6)
@@ -116,8 +116,8 @@ parse_priv_hdr_scn(struct rtas_event *re)
 
     rawhdr = (struct rtas_priv_hdr_scn_raw *)(re->buffer + re->offset);
     parse_v6_hdr(&privhdr->v6hdr, &rawhdr->v6hdr);
-    parse_rtas_date(&privhdr->date, &rawhdr->date);
-    parse_rtas_time(&privhdr->time, &rawhdr->time);
+    parse_rtas_date(&privhdr->date, rawhdr->date);
+    parse_rtas_time(&privhdr->time, rawhdr->time);
 
     privhdr->creator_id = rawhdr->creator_id;
     privhdr->scn_count = rawhdr->scn_count;


### PR DESCRIPTION
Address the warnings currently produced by the build and run the CI builds with -Werror to prevent new ones from being introduced.

Fixes #16 