### PR TITLE
get and set system parameters via /dev/lparctl

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,7 @@ librtas_la_SOURCES = \
 	librtas_src/syscall_rmo.c
 
 library_include_HEADERS += librtas_src/librtas.h
-noinst_HEADERS += librtas_src/syscall.h
+noinst_HEADERS += librtas_src/lparctl.h librtas_src/syscall.h
 
 lib_LTLIBRARIES += librtasevent.la
 librtasevent_la_LDFLAGS = -version-info $(LIBRTAS_LIBRARY_VERSION)

--- a/librtas_src/lparctl.h
+++ b/librtas_src/lparctl.h
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+#ifndef POWERPC_UAPI_LPARCTL_H
+#define POWERPC_UAPI_LPARCTL_H
+
+#include <linux/ioctl.h>
+#include <linux/types.h>
+
+#define LPARCTL_IOCTL_BASE 0xb2
+
+#define LPARCTL_IO(nr)         _IO(LPARCTL_IOCTL_BASE, nr)
+#define LPARCTL_IOR(nr, type)  _IOR(LPARCTL_IOCTL_BASE, nr, type)
+#define LPARCTL_IOW(nr, type)  _IOW(LPARCTL_IOCTL_BASE, nr, type)
+#define LPARCTL_IOWR(nr, type) _IOWR(LPARCTL_IOCTL_BASE, nr, type)
+
+/**
+ * struct lparctl_get_system_parameter - System parameter retrieval.
+ *
+ * @rtas_status: (output) The result of the ibm,get-system-parameter RTAS
+ *               call attempted by the kernel.
+ * @token: (input) System parameter token as specified in PAPR+ 7.3.16
+ *         "System Parameters Option".
+ * @data: (input and output) If applicable, any required input data ("OS
+ *        Service Entitlement Status" appears to be the only system
+ *        parameter that requires this). If @rtas_status is zero on return
+ *        from ioctl(), contains the value of the specified parameter. The
+ *        first two bytes contain the (big-endian) length of valid data in
+ *        both cases. If @rtas_status is not zero the contents are
+ *        indeterminate.
+ */
+struct lparctl_get_system_parameter {
+	__s32 rtas_status;
+	__u16 token;
+	union {
+		__be16 length;
+		__u8   data[4002];
+	};
+};
+
+#define LPARCTL_GET_SYSPARM LPARCTL_IOWR(0x01, struct lparctl_get_system_parameter)
+
+/**
+ * struct lparctl_set_system_parameter - System parameter update.
+ *
+ * @rtas_status: (output) The result of the ibm,get-system-parameter RTAS
+ *               call attempted by the kernel.
+ * @token: (input) System parameter token as specified in PAPR+ 7.3.16
+ *         "System Parameters Option".
+ * @data: (input) The desired value for the parameter corresponding to
+ *        @token. The first two bytes contain the (big-endian) length of
+ *        valid data.
+ */
+struct lparctl_set_system_parameter {
+	__s32 rtas_status;
+	__u16 token;
+	union {
+		__be16 length;
+		__u8   data[1026];
+	};
+};
+
+#define LPARCTL_SET_SYSPARM LPARCTL_IOWR(0x02, struct lparctl_set_system_parameter)
+
+#endif /* POWERPC_UAPI_LPARCTL_H */

--- a/librtas_src/syscall_calls.c
+++ b/librtas_src/syscall_calls.c
@@ -741,7 +741,7 @@ int rtas_get_sysparm(unsigned int parameter, unsigned int length, char *data)
 	int ret;
 
 	ret = get_sysparm_lparctl(parameter, length, data);
-	if (ret && (errno == ENOENT || errno == ENOIOCTLCMD))
+	if (ret && (errno == ENOENT || errno == ENOTTY))
 		ret = get_sysparm_devmem(parameter, length, data);
 	return ret;
 }
@@ -1274,8 +1274,8 @@ int rtas_set_sysparm(unsigned int parameter, /* const */ char *data)
 	int ret;
 
 	ret = set_sysparm_lparctl(parameter, data);
-	if (ret && (errno == ENOENT || errno == ENOIOCTLCMD))
-		ret = set_sysparm_devmem(paramter, data);
+	if (ret && (errno == ENOENT || errno == ENOTTY))
+		ret = set_sysparm_devmem(parameter, data);
 	return ret;
 }
 


### PR DESCRIPTION
Prefer the proposed /dev/lparctl interface for getting and setting system
parameters. Fall back to /dev/mem and sys_rtas if /dev/lparctl isn't
present or if the appropriate ioctl commands do not work.

lparctl.h is copied directly from the proposed kernel change:
https://lore.kernel.org/linuxppc-dev/20220730000458.130938-1-nathanl@linux.ibm.com/

Signed-off-by: Nathan Lynch <nathanl@linux.ibm.com>