### PR TITLE
rtas_platform_dump: fix uninitialized use of local variable

### DIFF
--- a/librtas_src/syscall_calls.c
+++ b/librtas_src/syscall_calls.c
@@ -886,7 +886,7 @@ int rtas_platform_dump(uint64_t dump_tag, uint64_t sequence, void *buffer,
 	uint32_t next_hi, next_lo;
 	uint32_t bytes_hi, bytes_lo;
 	uint32_t dump_tag_hi, dump_tag_lo;
-	void *kernbuf;
+	void *kernbuf = NULL;
 	int rc, status;
 
 	rc = sanity_check();


### PR DESCRIPTION
```
The Clang Static Analyzer correctly identifies an uninitialized use:

librtas_src/syscall_calls.c:930:6: warning: Branch condition evaluates to a
garbage value [core.uninitialized.Branch]
        if (kernbuf)
            ^~~~~~~

When rtas_platform_dump() is called with a NULL buffer argument,
rtas_free_rmo_buffer() is called with a stack garbage value for the buffer
address, which is ultimately passed to munmap().

Signed-off-by: Nathan Lynch <nathanl@linux.ibm.com>
```