### PR TITLE
librtas: fix buffer length determination in rtas_set_sysparm()

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
         echo "::add-matcher::.github/problem-matchers/compiler-source.json"
     - name: Install tools
       run: |
+        sudo apt-get update -qy
         sudo apt-get install -y qemu-user-static
     - name: Build and test
       run: |


### PR DESCRIPTION
The data passed by callers has this layout:

  struct {
      uint8_t len_msb;
      uint8_t len_lsb;
      char payload[];
  };

I.e. the length of valid data in payload[] is stored in the first two bytes of the buffer. However, rtas_set_sysparm() wrongly assumes that the length is in host-endian, leading to miscalculation of allocation and copy sizes.

For example, given this code in rtas_set_sysparm():

  int rtas_set_sysparm(unsigned int parameter, char *data) {
      ...
      size = *(short *)data;
      ...
      memcpy(kernbuf, data, size + sizeof(short));
      ...
  }

on little-endian targets, the following code:

    struct {
        uint16_t len_be;
        char data[1024];
    } sp_block = {
        .len_be = htobe16(sizeof"hello"),
        .data = "hello",
    };
    rtas_set_sysparm(0, (char *)&sp_block);

results in a copy of size ((6 << 8) + 2) = 1538, reading beyond the end of the passed object.

Similarly, objects with an encoded size of 256 or greater will result in copying too little data.

Extract the size from the buffer correctly, always treating it as big-endian.