### PR TITLE
librtas: sync papr-sysparm.h with kernel

### DIFF
--- a/librtas_src/papr-sysparm.h
+++ b/librtas_src/papr-sysparm.h
@@ -14,7 +14,7 @@ enum {
 struct papr_sysparm_io_block {
 	__u32 parameter;
 	__u16 length;
-	char data[PAPR_SYSPARM_MAX_OUTPUT];
+	__u8 data[PAPR_SYSPARM_MAX_OUTPUT];
 };
 
 /**


### PR DESCRIPTION
The data member is __u8 as of 8ded03ae48b3
("powerpc/pseries/papr-sysparm: use u8 arrays for payloads"):

https://git.kernel.org/pub/scm/linux/kernel/git/powerpc/linux.git/commit/?h=fixes&id=8ded03ae48b3657e0fbca99d8a9d8fa1bfb8c9be

Verified that the object code in librtas_src/sysparm.o is unchanged by this.